### PR TITLE
[json] add additional fields support in JSON formatter

### DIFF
--- a/src/main/minisite/content/jul-integration.adoc
+++ b/src/main/minisite/content/jul-integration.adoc
@@ -124,9 +124,10 @@ It can be done with this list for example:
 </dependency>
 ----
 
-TIP: the JSON formatter can be configured passing `json(useUUID=[false|true],formatMessage=[true|false],customEntriesMapper=<fqn of a Function<LogRecord, Map<String, String>>>)` value instead of just `json`. All configuration being optional.
+TIP: the JSON formatter can be configured passing `json(useUUID=[false|true];formatMessage=[true|false];customEntriesMapper=<fqn of a Function<LogRecord, Map<String, String>>>;field.<name>=<value>)` value instead of just `json`. All configuration being optional and options being separated by `;`.
 `formatMessage` enables to skip the message formatting when your application does not rely on it - faster and uses less the CPU, `useUUID` enables to force an unique ID in the record.
 `customEntriesMapper` enables to pass a function taking the log record and converting it to a map of data to append to the json object (must be `String` key/values).
+Any option prefixed with `field.` adds a *static* entry to every JSON record, the value being JSON-escaped by the formatter (no code needed); it is handy to stamp constant metadata such as `service.name`, e.g. `json(field.service.name=my-app;field.service.version=1.2.3)`.
 
 == Sample Configuration Files
 

--- a/yupiik-logging-jul/src/main/java/io/yupiik/logging/jul/YupiikLoggers.java
+++ b/yupiik-logging-jul/src/main/java/io/yupiik/logging/jul/YupiikLoggers.java
@@ -335,11 +335,17 @@ public class YupiikLoggers {
                     if (formatter.startsWith("json(") && formatter.endsWith(")")) {
                         final var conf = formatter.substring("json(".length(), formatter.length() - 1);
                         final var config = Stream.of(conf.split(";"))
-                                .map(it -> it.split("="))
+                                .map(it -> it.split("=", 2))
                                 .collect(toMap(it -> it[0], it -> it[1]));
                         final var jsonFormatter = new JsonFormatter();
                         jsonFormatter.setUseUUID(Boolean.parseBoolean(config.get("useUUID")));
                         jsonFormatter.setFormatMessage(Boolean.parseBoolean(config.get("formatMessage")));
+                        final var additionalFields = config.entrySet().stream()
+                                .filter(it -> it.getKey().startsWith("field."))
+                                .collect(toMap(it -> it.getKey().substring("field.".length()), Map.Entry::getValue));
+                        if (!additionalFields.isEmpty()) {
+                            jsonFormatter.setAdditionalFields(additionalFields);
+                        }
                         ofNullable(config.get("customEntriesMapper")).ifPresent(clazz -> {
                             try {
                                 jsonFormatter.setCustomEntriesMapper(ofNullable(Thread.currentThread().getContextClassLoader())

--- a/yupiik-logging-jul/src/main/java/io/yupiik/logging/jul/formatter/JsonFormatter.java
+++ b/yupiik-logging-jul/src/main/java/io/yupiik/logging/jul/formatter/JsonFormatter.java
@@ -35,6 +35,7 @@ public class JsonFormatter extends Formatter implements RecordFreezer {
     private boolean useUUID;
     private boolean formatMessage = true;
     private Function<LogRecord, Map<String, String>> customEntriesMapper = null;
+    private Map<String, String> additionalFields = Map.of();
 
     public void setCustomEntriesMapper(final Function<LogRecord, Map<String, String>> customEntriesMapper) {
         this.customEntriesMapper = customEntriesMapper;
@@ -46,6 +47,10 @@ public class JsonFormatter extends Formatter implements RecordFreezer {
 
     public void setUseUUID(final boolean useUUID) {
         this.useUUID = useUUID;
+    }
+
+    public void setAdditionalFields(final Map<String, String> additionalFields) {
+        this.additionalFields = additionalFields == null ? Map.of() : additionalFields;
     }
 
     @Override
@@ -102,7 +107,12 @@ public class JsonFormatter extends Formatter implements RecordFreezer {
         } else {
             appendMapperEnrichment(record, json);
         }
+        appendAdditionalFields(json);
         return json.append('}').toString() + '\n';
+    }
+
+    private void appendAdditionalFields(final StringBuilder json) {
+        additionalFields.forEach((k, v) -> json.append(",\"").append(k).append("\":").append(simpleEscape(v)));
     }
 
     private void appendMapperEnrichment(final LogRecord record, final StringBuilder json) {

--- a/yupiik-logging-jul/src/test/java/io/yupiik/logging/jul/YupiikLoggersTest.java
+++ b/yupiik-logging-jul/src/test/java/io/yupiik/logging/jul/YupiikLoggersTest.java
@@ -15,6 +15,7 @@
  */
 package io.yupiik.logging.jul;
 
+import io.yupiik.logging.jul.formatter.JsonFormatter;
 import io.yupiik.logging.jul.handler.StandardHandler;
 import org.junit.jupiter.api.Test;
 
@@ -22,12 +23,16 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Map;
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class YupiikLoggersTest {
     @Test
@@ -57,6 +62,52 @@ class YupiikLoggersTest {
         assertEquals(
                 "1970-01-01T00:00:00.000Z [INFO][YupiikLoggersTest.logAndConfigureLoggers] foo",
                 buffer.toString(StandardCharsets.UTF_8).trim());
+    }
+
+    @Test
+    void jsonFormatterAdditionalFieldsFromConfig() {
+        final var conf = Map.of(
+                TestHandler.class.getName() + ".formatter",
+                "json(useUUID=false;field.service.name=my-app;field.service.version=1.2.3;field.query=a=b)");
+        final var loggers = new YupiikLoggers() {
+            @Override
+            public String getProperty(final String name) {
+                return conf.get(name);
+            }
+        };
+
+        final var handler = new TestHandler();
+        loggers.initHandler(TestHandler.class.getName(), handler);
+
+        assertInstanceOf(JsonFormatter.class, handler.getFormatter(), () -> String.valueOf(handler.getFormatter()));
+
+        final var record = new LogRecord(Level.INFO, "hello");
+        record.setInstant(Instant.ofEpochMilli(0));
+        record.setLoggerName("the.logger");
+
+        final var formatted = handler.getFormatter().format(record);
+        assertTrue(formatted.startsWith("{\"timestamp\":\"1970-01-01T00:00Z\",\"level\":\"INFO\",\"logger\":\"the.logger\",\"message\":\"hello\","), formatted);
+        assertTrue(formatted.contains("\"service.name\":\"my-app\""), formatted);
+        assertTrue(formatted.contains("\"service.version\":\"1.2.3\""), formatted);
+        assertTrue(formatted.contains("\"query\":\"a=b\""), formatted);
+        assertTrue(formatted.endsWith("}\n"), formatted);
+    }
+
+    public static class TestHandler extends Handler {
+        @Override
+        public void publish(final LogRecord record) {
+            // no-op
+        }
+
+        @Override
+        public void flush() {
+            // no-op
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            flush();
+        }
     }
 
     public static class StdTestHandler extends StandardHandler {

--- a/yupiik-logging-jul/src/test/java/io/yupiik/logging/jul/formatter/JsonFormatterTest.java
+++ b/yupiik-logging-jul/src/test/java/io/yupiik/logging/jul/formatter/JsonFormatterTest.java
@@ -18,6 +18,7 @@ package io.yupiik.logging.jul.formatter;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -44,6 +45,21 @@ class JsonFormatterTest {
                         "\"logger\":\"the.logger\",\"method\":\"the.method\",\"message\":\"test message\"," +
                         "\"class\":\"the.source\"}\n"),
                 formatted);
+    }
+
+    @Test
+    void formatWithAdditionalFields() {
+        final var record = createRecord();
+        record.setThrown(null);
+        final var jsonFormatter = new JsonFormatter();
+        final var fields = new LinkedHashMap<String, String>();
+        fields.put("service.name", "my-app");
+        fields.put("quote", "a\"b");
+        jsonFormatter.setAdditionalFields(fields);
+        assertEquals("{\"timestamp\":\"1970-01-01T00:00Z\",\"level\":\"INFO\",\"logger\":\"the.logger\"," +
+                        "\"method\":\"the.method\",\"message\":\"test message\",\"class\":\"the.source\"," +
+                        "\"service.name\":\"my-app\",\"quote\":\"a\\\"b\"}\n",
+                jsonFormatter.format(record));
     }
 
     private LogRecord createRecord() {


### PR DESCRIPTION
The aim of that PR is to provide extra fields support in JSON formatter without wiring a Function<LogRecord, Map<String, String>. It's usefull to enrich logs with values coming from configuration.

Any option prefixed with `field.` is added as-is to every JSON record.

`handler.formatter = json(field.service.name=my-app;field.service.version=1.2.3)`                                                                                                                                                                                                                             

produces:
 
```json                                                                                                                                                                                                                                                                                                             
  {"timestamp":"...","level":"INFO","message":"...","service.name":"my-app","service.version":"1.2.3"}                                                                                                                                                                                                        
```                                                                                                                                                                                                                                                                                                   

NB, I also fixed the  config parsing to handle values containing `=` character

